### PR TITLE
chore: Specify snapshot repo as plugin repository in Jenkins build script

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -87,7 +87,7 @@ echo " "
 
 # Compiles project.
 START_COMPILE_PROJECT=$(($(date +%s%N)/1000000))
-$MAVEN_COMMAND clean install
+$MAVEN_COMMAND clean install -U
 if [ "$?" -ne 0 ]; then
     echo "Error: Maven compile original project unsuccessful!"
     exit 1

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -173,7 +173,13 @@ xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n groupId -v "fr.inria.gforge.spoon" pom.bak19.xml > pom.bak20.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n artifactId -v "spoon-core" pom.bak20.xml > pom.bak21.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "[8.4.0-SNAPSHOT,)" pom.bak21.xml > pom.bak22.xml
-mv pom.bak22.xml pom.xml
+
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies" --type elem -n dependency -v "" pom.bak22.xml > pom.bak23.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n groupId -v "org.slf4j" pom.bak23.xml > pom.bak24.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n artifactId -v "slf4j-api" pom.bak24.xml > pom.bak25.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "1.7.30" pom.bak25.xml > pom.bak26.xml
+
+mv pom.bak26.xml pom.xml
 rm pom.bak*.xml
 
 # Purge the project from snapshots

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -172,7 +172,7 @@ xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies" --type elem -n dependency -v "" pom.bak14.xml > pom.bak19.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n groupId -v "fr.inria.gforge.spoon" pom.bak19.xml > pom.bak20.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n artifactId -v "spoon-core" pom.bak20.xml > pom.bak21.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "8.4.0-SNAPSHOT" pom.bak21.xml > pom.bak22.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "[8.4.0-SNAPSHOT,)" pom.bak21.xml > pom.bak22.xml
 mv pom.bak22.xml pom.xml
 rm pom.bak*.xml
 

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -143,12 +143,12 @@ echo "-------------------------------------------------------"
 echo " "
 
 # Edits pom xml to prepare project to spoon project.
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project" --type elem -n repositories -v "" pom.xml > pom.bak.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories" --type elem -n repository -v "" pom.bak.xml > pom.bak1.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n id -v "maven.inria.fr-snapshot" pom.bak1.xml > pom.bak2.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n name -v "Maven Repository for Spoon Snapshot" pom.bak2.xml > pom.bak3.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n url -v "http://maven.inria.fr/artifactory/spoon-public-snapshot/" pom.bak3.xml > pom.bak4.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n snapshots -v "" pom.bak4.xml > pom.bak5.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project" --type elem -n pluginRepositories -v "" pom.xml > pom.bak.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories" --type elem -n pluginRepository -v "" pom.bak.xml > pom.bak1.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n id -v "ow2.org-snapshot" pom.bak1.xml > pom.bak2.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n name -v "Maven repository for Spoon Snapshot" pom.bak2.xml > pom.bak3.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n url -v "http://maven.inria.fr/artifactory/spoon-public-snapshot/" pom.bak3.xml > pom.bak4.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n snapshots -v "" pom.bak4.xml > pom.bak5.xml
 mv pom.bak5.xml pom.xml
 rm pom.bak*.xml
 

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -147,7 +147,7 @@ xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project" --type el
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories" --type elem -n pluginRepository -v "" pom.bak.xml > pom.bak1.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n id -v "ow2.org-snapshot" pom.bak1.xml > pom.bak2.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n name -v "Maven repository for Spoon Snapshot" pom.bak2.xml > pom.bak3.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n url -v "http://maven.inria.fr/artifactory/spoon-public-snapshot/" pom.bak3.xml > pom.bak4.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n url -v "https://repository.ow2.org/nexus/content/repositories/snapshots/" pom.bak3.xml > pom.bak4.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:pluginRepositories/x:pluginRepository[last()]" --type elem -n snapshots -v "" pom.bak4.xml > pom.bak5.xml
 mv pom.bak5.xml pom.xml
 rm pom.bak*.xml

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -87,7 +87,7 @@ echo " "
 
 # Compiles project.
 START_COMPILE_PROJECT=$(($(date +%s%N)/1000000))
-$MAVEN_COMMAND clean install -U
+$MAVEN_COMMAND clean install
 if [ "$?" -ne 0 ]; then
     echo "Error: Maven compile original project unsuccessful!"
     exit 1
@@ -172,14 +172,8 @@ xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies" --type elem -n dependency -v "" pom.bak14.xml > pom.bak19.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n groupId -v "fr.inria.gforge.spoon" pom.bak19.xml > pom.bak20.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n artifactId -v "spoon-core" pom.bak20.xml > pom.bak21.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "[8.4.0-SNAPSHOT,)" pom.bak21.xml > pom.bak22.xml
-
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies" --type elem -n dependency -v "" pom.bak22.xml > pom.bak23.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n groupId -v "org.slf4j" pom.bak23.xml > pom.bak24.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n artifactId -v "slf4j-api" pom.bak24.xml > pom.bak25.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "1.7.30" pom.bak25.xml > pom.bak26.xml
-
-mv pom.bak26.xml pom.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "[7.0.0-SNAPSHOT,)" pom.bak21.xml > pom.bak22.xml
+mv pom.bak22.xml pom.xml
 rm pom.bak*.xml
 
 # Purge the project from snapshots

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -172,7 +172,7 @@ xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies" --type elem -n dependency -v "" pom.bak14.xml > pom.bak19.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n groupId -v "fr.inria.gforge.spoon" pom.bak19.xml > pom.bak20.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n artifactId -v "spoon-core" pom.bak20.xml > pom.bak21.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "[7.0.0-SNAPSHOT,)" pom.bak21.xml > pom.bak22.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:build/x:plugins/x:plugin[last()]/x:dependencies/x:dependency[last()]" --type elem -n version -v "8.4.0-SNAPSHOT" pom.bak21.xml > pom.bak22.xml
 mv pom.bak22.xml pom.xml
 rm pom.bak*.xml
 


### PR DESCRIPTION
This PR does two things:

1. Updates the snapshot repository to the new OW2 Nexus repo
2. Specifies this repository in `<pluginRepositories>` instead of `<repositories>`. This causes Maven to use this repository when searching for dependencies of plugins.

This doesn't solve the infernal logger problem, but at least it causes the build script to pull down the snapshot version of Spoon instead of the latest beta (see inria/spoon#3775 for details). You can see from this build in which I pointed it to this exact script version, that it actually now pulls down 8.4.0-SNAPSHOT: https://ci.inria.fr/sos/job/Jimfs/1551/console (toward the bottom)

As opposed to e.g. this build, where 8.4.0-beta-13 is pulled: https://ci.inria.fr/sos/job/Commons-codec/1990/console

So, this is at least one step closer to correct behavior on Jenkins. A small step.