### PR TITLE
chore: Add automatic deployment

### DIFF
--- a/.github/deploy_website.sh
+++ b/.github/deploy_website.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Deploys the current Spoon website to the website server.
+# To test the site locally before deploying run `jekyll serve`
+# in the website branch.
+#
+# Non-standard software required: ruby 2.4+, Jekyll 4.0+, xmlstarlet, jq, git, curl, Maven, JDK8+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function generate_website() {
+    # Generate the website
+    generate_javadoc
+
+    cd "$WEBSITE_SOURCE_DIR"
+    cp ../README.md doc_homepage.md
+
+    LATESTVERSION=`curl -s "http://search.maven.org/solrsearch/select?q=g:%22fr.inria.gforge.spoon%22+AND+a:%22spoon-core%22&core=gav" | jq -r '.response.docs | map(select(.v | match("^[0-9.]+$")) | .v )| .[0]'`
+    sed -i -e "s/^spoon_release: .*/spoon_release: $LATESTVERSION/" _config.yml
+    SNAPSHOTVERSION=`xmlstarlet sel -t -v /_:project/_:version ../pom.xml`
+    sed -i -e "s/^spoon_snapshot: .*/spoon_snapshot: \"$SNAPSHOTVERSION\"/" _config.yml
+    jekyll build
+}
+
+function generate_javadoc() {
+    # Generate Javadoc and place it in the website sources
+    cd "$SOURCE_DIR"
+    mvn -B site
+
+    mkdir "$WEBSITE_SOURCE_DIR"/mvnsites/
+    cp -r target/site/ "$WEBSITE_SOURCE_DIR"/mvnsites/spoon-core
+}
+
+
+function configure_git() {
+    git config --local user.email "$GITHUB_USER"@users.noreply.github.com
+    git config --local user.name "$GITHUB_USER"
+}
+
+function update_website() {
+    # Update the existing website with the enwly generated one
+    cd "$WEBSITE_DST_DIR"
+
+    git init -b "$WEBSITE_BRANCH"
+    configure_git
+
+    git remote add origin "$WEBSITE_REPO_URL"
+    git fetch origin
+
+    # this is intricate; we update the HEAD reference without updating the working directory,
+    # and then copy the website into the working directory and force-commit it
+    git update-ref refs/heads/"$WEBSITE_BRANCH" refs/remotes/origin/"$WEBSITE_BRANCH"
+    # must restore workflows
+    git restore --staged .github/
+    git restore .github/
+
+    cp -r "$WEBSITE_GENERATED_DIR"/* .
+
+    # clobber the README with a notice that the website is automatically generated
+    echo '# Spoon website
+This is the Spoon website hosted on GitHub pages. It is automatically generated
+and deployed with a GitHub Actions workflow. See
+[.github/workflows/deploy.yml](.github/workflows/deploy.yml).
+
+> **Note:** The deploy workflow overwrites everything on the main branch
+> _except_ for the [.github](.github) directory. Therefore, everything in the
+> [.github](.github) directory is retained on automatic deployment, and you can
+> edit its contents as usual, but files anywhere else are removed or overwritten.' > README.md
+
+
+    git add . --force
+    git commit -m "Update website" || {
+        echo "Nothing to commit, website up-to-date"
+        return
+    }
+
+    git push "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/$WEBSITE_REPO_SLUG" "$WEBSITE_BRANCH"
+}
+
+function deploy() {
+    # Deploy the website
+    cd "$INITIAL_WORKDIR"
+    mkdir "$WEBSITE_DST_DIR"
+    git clone "$SOURCE_REPO_URL" "$SOURCE_DIR"
+
+    generate_website
+    update_website
+}
+
+NUM_ARGS=3
+if [[ "$#" -ne "$NUM_ARGS" ]]; then
+    echo "usage: deploy_website.sh <workdir> <github_user> <github_token>"
+    exit 1
+fi
+
+INITIAL_WORKDIR="$1"
+GITHUB_USER="$2"
+GITHUB_TOKEN="$3"
+
+SOURCE_REPO_URL="https://github.com/INRIA/spoon.git"
+SOURCE_DIR="$INITIAL_WORKDIR/temp-spoon-clone"
+WEBSITE_SOURCE_DIR="$SOURCE_DIR/doc"
+WEBSITE_GENERATED_DIR="$WEBSITE_SOURCE_DIR/_site"
+WEBSITE_DST_DIR="$INITIAL_WORKDIR/spoon-website"
+#WEBSITE_REPO_SLUG="SpoonLabs/spoonlabs.github.io" # TODO use
+WEBSITE_REPO_SLUG="slarse/spoonlabs.github.io" # TODO remove
+WEBSITE_REPO_URL="https://github.com/$WEBSITE_REPO_SLUG"
+WEBSITE_BRANCH="main"
+
+deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+# Workflow for deploying the website
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  deploy-website:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@034294ac9150f471c8dd554f05f0685312e7f7bd # v1.66.0
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
+      - name: Setup Java
+        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
+        with:
+          java-version: 1.8
+      - name: Install prerequisites
+        run: |
+          sudo apt update
+          sudo apt install xmlstarlet jq curl
+          gem install jekyll bundler
+
+      - name: Update website
+        run: |
+          WORKDIR="$HOME"/tmp
+          mkdir "$WORKDIR"
+
+          bash .github/deploy_website.sh "$WORKDIR" "github-actions[bot]" ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Related to inria/spoon#3759

This PR adds an automatic deployment script and associated GitHub Actions workflow.

It works as follows.

1. The workflow activates once a day (hour=0, minute=0).
2. It pretty much just installs some software and runs `.github/deploy_website.sh`
3. The deployment script pulls the latest version of Spoon and:
    - Builds the docs
    - Generates the website (with docs)
    - Clobbers the README with [this notice](https://github.com/slarse/SpoonLabs.github.io/blob/main/README.md)
    - Pulls some Git stunts to update the website, but retain the `.github` directory (the workflow must be on the main branch for schedule to work)
    - Pushes to the main branch

That's the gist of it. It's entirely possible to put _all_ of this in the proper Spoon repo, but there are two reasons for why I'm putting it in this repo right now:

1. We'll probably want to tweak the deployment script (e.g. only update website when there's actually a new commit in Spoon)
2. The credentials to push to this repo are already available in the workflow, whereas we'd need to add them to the Spoon repo ourselves. It's always nice to not have to push credentials around.

So, for now, I suggest we keep the auto-deployment of the website right here. I'll do a separate PR to Spoon to update the documentation on how the website is built, so this doesn't fall into tribal word-of-mouth knowledge. Once everything is working super smoothly and we're happy with the details, we can move the auto-deployment to a scheduled workflow in the core Spoon repo, or to Jenkins, if we wish it.

Ps. If you merge this today, we'll see if it works by tomorrow! :)