### PR TITLE
chore: Run update script weekly instead of daily

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
 
 jobs:
   deploy-website:


### PR DESCRIPTION
@monperrus The little tweak you added before didn't work, there's still metadata being updated every time we run the deploy script. I'm taking the easy way out here and am reducing the update frequency to once a week.

Please merge ASAP, this repo is growing absolutely huge :)