### PR TITLE
Use JDK 16 to generate Javadoc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,16 +8,17 @@ jobs:
   deploy-website:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@034294ac9150f471c8dd554f05f0685312e7f7bd # v1.66.0
+        uses: ruby/setup-ruby@034294ac9150f471c8dd554f05f0685312e7f7bd # renovate: tag=v1.66.0
         with:
           ruby-version: 2.7.2
           bundler-cache: true
       - name: Setup Java
-        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
+      - uses: actions/setup-java@8db439b6b47e5e12312bf036760bbaa6893481ac # renovate: tag=v2.3.1
         with:
-          java-version: 11
+          java-version: 16
+          distribution: temurin
       - name: Install prerequisites
         run: |
           sudo apt update

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
           ruby-version: 2.7.2
           bundler-cache: true
       - name: Setup Java
-      - uses: actions/setup-java@8db439b6b47e5e12312bf036760bbaa6893481ac # renovate: tag=v2.3.1
+        uses: actions/setup-java@8db439b6b47e5e12312bf036760bbaa6893481ac # renovate: tag=v2.3.1
         with:
           java-version: 16
           distribution: temurin


### PR DESCRIPTION
As noted in inria/spoon#4292, search is broken when generating Javadoc with JDK 11. With JDK 16 we get some additional nice bells and whistles such as properly linked standard library classes. So I say we go with JDK 16.

While I was rooting around in the workflow file anyway, I also prepped it for Renovate updates. @monperrus could you activate renovate on this repo?